### PR TITLE
chore: configure just-the-docs theme

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -11,20 +11,20 @@ gem 'github-pages', group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.12'
+  gem 'jekyll-remote-theme'
   gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
-  gem 'jekyll-remote-theme'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
-platforms :mingw, :x64_mingw, :mswin, :jruby do
+platforms :windows, :jruby do
   gem 'tzinfo', '>= 1', '< 3'
   gem 'tzinfo-data'
 end
 
 # Performance-booster for watching directories on Windows
-gem 'wdm', '~> 0.1', platforms: %i[mingw x64_mingw mswin]
+gem 'wdm', '~> 0.1', platforms: [:windows]
 
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -5,14 +5,15 @@ source 'https://rubygems.org'
 # Use GitHub Pages for deployment
 gem 'github-pages', group: :jekyll_plugins
 
-# Use Just the Docs theme
-gem 'just-the-docs'
+# Use Just the Docs theme (included in github-pages gem)
+# gem 'just-the-docs' # This is included in github-pages gem
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.12'
   gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
+  gem 'jekyll-remote-theme'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -228,11 +228,6 @@ GEM
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
     json (2.15.0)
-    just-the-docs (0.10.1)
-      jekyll (>= 3.8.5)
-      jekyll-include-cache
-      jekyll-seo-tag (>= 2.0)
-      rake (>= 12.3.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -277,7 +272,6 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (5.1.1)
     racc (1.8.1)
-    rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -330,9 +324,9 @@ DEPENDENCIES
   github-pages
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)
+  jekyll-remote-theme
   jekyll-seo-tag
   jekyll-sitemap
-  just-the-docs
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,14 +4,15 @@ description: Generate cryptographically secure, collision-free opaque IDs for Ac
 url: "https://nyaggah.github.io"
 baseurl: "/opaque_id"
 
-# Just the Docs theme
-theme: just-the-docs
+# Just the Docs theme (via remote_theme for GitHub Pages compatibility)
+remote_theme: just-the-docs/just-the-docs
 
 # GitHub Pages plugins
 plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag
+  - jekyll-remote-theme
 
 # Feed configuration
 feed:


### PR DESCRIPTION
- [fix: configure just-the-docs theme for GitHub Pages compatibility](https://github.com/nyaggah/opaque_id/commit/c2fb96c46e99fd5287520e01c3bc2dd7bd5d4817)
- [fix: update deprecated platform specifications in docs/Gemfile](https://github.com/nyaggah/opaque_id/commit/cf9613499150dd7152bff38aa8f8fe7ab9923eb5)
- [chore: update Gemfile.lock after dependency check](https://github.com/nyaggah/opaque_id/commit/058281f6e07f3c9a1057c6fbeb0200bccf221558)